### PR TITLE
Update bmap-wx.js

### DIFF
--- a/src/bmap-wx.js
+++ b/src/bmap-wx.js
@@ -239,8 +239,8 @@ class BMapWX {
                         outputRes["wxMarkerData"] = [];    
                         outputRes["wxMarkerData"][0] = {
                             id: 0,
-                            latitude: result["latitude"],
-                            longitude: result["longitude"],
+                            latitude: poiObj["location"]["lat"],
+                            longitude: poiObj["location"]["lng"],
                             address: poiObj["formatted_address"],
                             iconPath: otherparam["iconPath"],
                             iconTapPath: otherparam["iconTapPath"],


### PR DESCRIPTION
修复反查时传入坐标非gcj02时，返回的坐标不准确问题